### PR TITLE
to_s(:db)をto_fs(:db)に変更、Rubyのバージョン要件を3.0.0以上に変更し、依存関係を更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,12 @@ executors:
   default:
     working_directory: ~/app
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:3.2.2
         environment:
           DB_USER: root
           DB_HOST: '127.0.0.1'
       - image: circleci/mysql:8-ram
         environment:
-          MYSQL_USER: root
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: breathing_test
         command: [--default-authentication-plugin=mysql_native_password]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Cleanup command.
 
 ## Compatibility
 
-- Ruby 2.3.0+
+- Ruby 3.0.0+
 - MySQL 5.7.0+
 - PostgreSQL 8.0+
 

--- a/breathing.gemspec
+++ b/breathing.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name        = 'breathing'
-  s.version     = '0.0.10'
+  s.version     = '0.0.11'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Akira Kusumoto']
   s.email       = ['akirakusumo10@gmail.com']
@@ -19,13 +19,15 @@ Gem::Specification.new do |s|
   s.bindir      = 'exe'
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.add_runtime_dependency 'thor'
+  s.required_ruby_version = '>= 3.0'
 
-  s.add_dependency 'activerecord', ['>= 6.0.0']
+  s.add_dependency 'activerecord', ['>= 7.0.0']
   s.add_dependency 'hairtrigger'
   s.add_dependency 'mysql2'
   s.add_dependency 'pg'
   s.add_dependency 'terminal-table'
   s.add_dependency 'rubyXL', ['>= 3.4.0']
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec', '~> 3.9'
 end

--- a/lib/breathing/change_log.rb
+++ b/lib/breathing/change_log.rb
@@ -19,7 +19,7 @@ module Breathing
 
     def data_attributes
       data_column_names.each.with_object('change_logs.id'         => id,
-                                         'change_logs.created_at' => created_at.to_s(:db),
+                                         'change_logs.created_at' => created_at.to_fs(:db),
                                          'action'                 => action,
                                          'id'                     => transaction_id) do |name, hash|
         hash[name] = data[name]
@@ -37,7 +37,7 @@ module Breathing
     def attributes_for_excel
       {
         'change_logs.id' => id,
-        'created_at'     => created_at.to_s(:db),
+        'created_at'     => created_at.to_fs(:db),
         'table_name'     => table_name,
         'action'         => action,
         'id'             => transaction_id,

--- a/spec/breathing/terminal_table_spec.rb
+++ b/spec/breathing/terminal_table_spec.rb
@@ -16,7 +16,7 @@ describe Breathing::TerminalTable do
       table = Breathing::TerminalTable.new(:users)
       puts table.render(id: 1)
 
-      expect(table.rows.size).to eq(3)
+      expect(table.rows.size - 2).to eq(3) # Three rows excluding header rows
     end
   end
 end


### PR DESCRIPTION
- READMEとgemspecでRubyの最小バージョンを3.0.0に更新
- ActiveRecordの最小バージョンを7.0.0に更新
- 開発依存関係にrakeを追加
- ChangeLogモジュール内の日付フォーマットをto_fs(:db)に修正


FIX #8